### PR TITLE
README had a typo error -- Fixed

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@
 ## Links to the given Genres:
 [Apni Kaksha](https://github.com/kaiwalyakoparkar/Data-Structures-And-Algorithm-Interview-Kit/tree/main/Apni_Kaksha)
 
-[Competitive rogramming](https://github.com/kaiwalyakoparkar/Data-Structures-And-Algorithm-Interview-Kit/tree/main/Competitive_Programming)
+[Competitive Programming](https://github.com/kaiwalyakoparkar/Data-Structures-And-Algorithm-Interview-Kit/tree/main/Competitive_Programming)
 
 [Pep Coding](https://github.com/kaiwalyakoparkar/Data-Structures-And-Algorithm-Interview-Kit/tree/main/Pep_Coding)
 


### PR DESCRIPTION
<!--Type in all the issues that has been fixed through this pull request ex : #1 -->

## Fixes Issue

<H4>This PR fixes the following issues :</H4>
README.md had a typo error on line 32 where "Competitive Programming" is written as "Competitive rogramming".

<!--Write down all the changes made-->
I have change the spell error of "Programming" successfully.

<!--Add screen shots of the changed output-->
![Screenshot_2022-09-27_12-55-15](https://user-images.githubusercontent.com/112618578/192461355-bbacf1b4-7b7c-46b1-8f94-2af66331c79e.png)

<H4>ADDED A SCREENSHOT OF THE ERROR THAT IS FIXED.</H4>

Thank You.